### PR TITLE
Capture multiple event triggers as long as they relate to different user

### DIFF
--- a/classes/manager.php
+++ b/classes/manager.php
@@ -105,7 +105,7 @@ class block_xp_manager {
         }
 
         // Check if the user is trying to trick the system by reloading a page.
-        $key = $event->eventname . ':' . $event->contextid;
+        $key = $event->eventname . ':' . $event->contextid . ':' . $event->userid;
         if (isset($SESSION->block_xp_buffer[$key])) {
             if ($SESSION->block_xp_buffer[$key] > time() - 30) {
                 // A very similar event occured less than 30 seconds ago, we will ignore it.


### PR DESCRIPTION
This is my use case: in the Stamp collection module, the teacher can
give stamps to multiple users at once. Each time the stamp is given, the
event is triggered. The current check caused only the first processed
student received the XP, all other were ignored (as the same event was
triggered in the same context at the almost same time).

This patch allows to capture the same event in the same context if the
event's user is different. It will still prevent users themselves to
fake the xp capturing by quick reloading the browser.