### PR TITLE
to fix where composer installs the plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,9 @@
     "require": {
         "composer/installers": "*"
     },
+    "extra": {
+        "installer-name": "xp"
+    },
     "support": {
         "issues": "https://github.com/FMCorz/moodle-block_xp/issues",
         "source": "https://github.com/FMCorz/moodle-block_xp"


### PR DESCRIPTION
Hello,

this is needed for composer to install the plugin under blocks/xp instead of blocks/moodle-block_xp

Kind regards,
Daniel