### PR TITLE
Fix default order by SQL

### DIFF
--- a/classes/output/report_table.php
+++ b/classes/output/report_table.php
@@ -322,12 +322,12 @@ class report_table extends table_sql {
 
             // Ensure that sorting by level sub sorts by xp to avoid random ordering.
             if (array_key_exists('lvl', $orderby) && !array_key_exists('xp', $orderby)) {
-                $orderby['xp'] = $orderby['lvl'];
+                $orderby[] = array('xp' => $orderby['lvl']);
             }
 
             // Always add the user ID, to avoid random ordering.
             if (!array_key_exists('id', $orderby)) {
-                $orderby['id'] = SORT_ASC;
+                $orderby[] = array('id' => SORT_ASC);
             }
         }
 


### PR DESCRIPTION
Hi @FMCorz

When 'Where are points used? ' set to 'For the whole site', accessing /blocks/xp/index.php/report/1 page causes below dml issue. its due to default ordering. Please review PR and merge. Our clients are facing issues.
Thank you,
Heena

========================================
Debug info: ERROR: syntax error at or near "DESC"
LINE 10: ORDER BY lvl DESC, DESC LIMIT 20 OFFSET 0
^
SELECT
u.id,u.picture,u.firstname,u.lastname,u.firstnamephonetic,u.lastnamephonetic,u.middlename,u.alternatename,u.imagealt,u.email, COALESCE(x.lvl, 1) AS lvl, x.xp, ctx.id AS ctxid, ctx.path AS ctxpath, ctx.depth AS ctxdepth, ctx.contextlevel AS ctxlevel, ctx.instanceid AS ctxinstance
FROM mdl_user u
JOIN mdl_context ctx
ON ctx.instanceid = u.id
AND ctx.contextlevel = $1
LEFT JOIN mdl_block_xp x
ON (x.userid = u.id AND x.courseid = $2)
WHERE u.id IS NULL
ORDER BY lvl DESC, DESC LIMIT 20 OFFSET 0
[array (
0 => 30,
1 => 1,
)]
Error code: dmlreadexception