### PR TITLE
fixed contextlevel of addinstance capability

### DIFF
--- a/db/access.php
+++ b/db/access.php
@@ -29,7 +29,7 @@ $capabilities = array(
     // Whether or not the user can add the block.
     'block/xp:addinstance' => array(
         'captype' => 'write',
-        'contextlevel' => CONTEXT_SYSTEM,
+        'contextlevel' => CONTEXT_BLOCK,
         'archetypes' => array(
             'editingteacher' => CAP_ALLOW,
             'manager' => CAP_ALLOW

--- a/version.php
+++ b/version.php
@@ -24,7 +24,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version    = 2021042802;
+$plugin->version    = 2021082700;
 $plugin->requires   = 2016052300;   // Moodle 3.1.0.
 $plugin->component  = 'block_xp';
 $plugin->maturity   = MATURITY_STABLE;


### PR DESCRIPTION
The addinstance capabiltiy usually has contextlevel "block". At the moment you can't overwrite addinstance for specific courses because it has contextlevel "system". Unless there is a reason for that I suggest changing it to "block".