### PR TITLE
ISSUE-180: Fix addon_compability details error.

### DIFF
--- a/classes/local/check/addon_compatibility.php
+++ b/classes/local/check/addon_compatibility.php
@@ -69,7 +69,7 @@ class addon_compatibility extends \core\check\check {
      * @return array
      */
     protected function compute_result() {
-        $noissues = [result::OK, get_string('noissuesidentified', 'block_xp'), null];
+        $noissues = [result::OK, get_string('noissuesidentified', 'block_xp'), ''];
         if (!addon::is_container_present()) {
             return $noissues;
         }


### PR DESCRIPTION
Error: Return value must be of type string, null returned.

The result get_details() method expects a string. So this has been changed to an empty string ''.

Fixes #180 