### PR TITLE
Remove table borders even in Bootstrap 5.

### DIFF
--- a/templates/recent-activity.mustache
+++ b/templates/recent-activity.mustache
@@ -41,7 +41,7 @@
         </div>
         {{/x}}
 
-        <table class="xp-w-full xp-border-0">
+        <table class="xp-w-full xp-border-0 table-reboot">
         {{#recentactivities}}
             <tr>
                 <td class="xp-align-top xp-p-0 xp-pr-2">{{{xphtml}}}</td>


### PR DESCRIPTION
This removes the undesired table border in Moodle 5 onwards which relies on Bootstrap 5.
Note this requires Moodle 5.0.3, since that is the version that introduced the .table-reboot class.